### PR TITLE
Use timestamps for byte code invalidation

### DIFF
--- a/rpm/0006-pyc-timestamp-invalidation-mode.patch
+++ b/rpm/0006-pyc-timestamp-invalidation-mode.patch
@@ -1,0 +1,54 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Miro=20Hron=C4=8Dok?= <miro@hroncok.cz>
+Date: Thu, 11 Jul 2019 13:44:13 +0200
+Subject: [PATCH] 00328: Restore pyc to TIMESTAMP invalidation mode as default
+ in rpmbuild
+
+Since Fedora 31, the $SOURCE_DATE_EPOCH is set in rpmbuild to the latest
+%changelog date. This makes Python default to the CHECKED_HASH pyc
+invalidation mode, bringing more reproducible builds traded for an import
+performance decrease. To avoid that, we don't default to CHECKED_HASH
+when $RPM_BUILD_ROOT is set (i.e. when we are building RPM packages).
+
+See https://src.fedoraproject.org/rpms/redhat-rpm-config/pull-request/57#comment-27426
+Downstream only: only used when building RPM packages
+Ideally, we should talk to upstream and explain why we don't want this
+---
+ Lib/py_compile.py           | 3 ++-
+ Lib/test/test_py_compile.py | 2 ++
+ 2 files changed, 4 insertions(+), 1 deletion(-)
+
+diff --git a/Lib/py_compile.py b/Lib/py_compile.py
+index a81f493731..bba3642bf2 100644
+--- a/Lib/py_compile.py
++++ b/Lib/py_compile.py
+@@ -70,7 +70,8 @@ class PycInvalidationMode(enum.Enum):
+ 
+ 
+ def _get_default_invalidation_mode():
+-    if os.environ.get('SOURCE_DATE_EPOCH'):
++    if (os.environ.get('SOURCE_DATE_EPOCH') and not
++            os.environ.get('RPM_BUILD_ROOT')):
+         return PycInvalidationMode.CHECKED_HASH
+     else:
+         return PycInvalidationMode.TIMESTAMP
+diff --git a/Lib/test/test_py_compile.py b/Lib/test/test_py_compile.py
+index e6791c6916..b2d3dcf7fb 100644
+--- a/Lib/test/test_py_compile.py
++++ b/Lib/test/test_py_compile.py
+@@ -19,6 +19,7 @@ def without_source_date_epoch(fxn):
+     def wrapper(*args, **kwargs):
+         with support.EnvironmentVarGuard() as env:
+             env.unset('SOURCE_DATE_EPOCH')
++            env.unset('RPM_BUILD_ROOT')
+             return fxn(*args, **kwargs)
+     return wrapper
+ 
+@@ -29,6 +30,7 @@ def with_source_date_epoch(fxn):
+     def wrapper(*args, **kwargs):
+         with support.EnvironmentVarGuard() as env:
+             env['SOURCE_DATE_EPOCH'] = '123456789'
++            env.unset('RPM_BUILD_ROOT')
+             return fxn(*args, **kwargs)
+     return wrapper
+ 

--- a/rpm/python3-extra.spec
+++ b/rpm/python3-extra.spec
@@ -43,6 +43,8 @@ Patch2:         0003-00001-Fixup-distutils-unixccompiler.py-to-remove-sta.patch
 Patch3:         0004-00102-Change-the-various-install-paths-to-use-usr-li.patch
 # Ensurepip should honour the value of $(prefix)
 Patch4:         0005-bpo-31046-ensurepip-does-not-honour-the-value-of-pre.patch
+# Restore pyc to TIMESTAMP invalidation mode as default
+Patch5:         0006-pyc-timestamp-invalidation-mode.patch
 
 %description
 Additional base modules for Python.
@@ -92,6 +94,7 @@ This package contains the sqlite module for Python.
 %patch3 -p1
 %endif
 %patch4 -p1
+%patch5 -p1
 
 %build
 # use rpm_opt_flags

--- a/rpm/python3.spec
+++ b/rpm/python3.spec
@@ -62,6 +62,8 @@ Patch2:         0003-00001-Fixup-distutils-unixccompiler.py-to-remove-sta.patch
 Patch3:         0004-00102-Change-the-various-install-paths-to-use-usr-li.patch
 # Ensurepip should honour the value of $(prefix)
 Patch4:         0005-bpo-31046-ensurepip-does-not-honour-the-value-of-pre.patch
+# Restore pyc to TIMESTAMP invalidation mode as default
+Patch5:         0006-pyc-timestamp-invalidation-mode.patch
 
 %define         python_version  3.8
 %define         python_version_abitag   38
@@ -180,6 +182,7 @@ This package provides man pages for %{name}.
 %patch3 -p1
 %endif
 %patch4 -p1
+%patch5 -p1
 
 # drop Autoconf version requirement
 sed -i 's/^AC_PREREQ/dnl AC_PREREQ/' configure.ac


### PR DESCRIPTION
~~Make builds more reproducible by telling rpmbuild to set SOURCE_DATE_EPOCH variable from timestamp in changelog.~~ [EDIT: Done elsewhere.] However, building this can still generate different byte code in pyc files so that they don't match to previous build.

Add a patch from Fedora to mitigate the effect on import performance.